### PR TITLE
Add createSong and createLyrics api

### DIFF
--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -57,3 +57,31 @@ export function toDbSongbook(data: any): DbSongbook {
     imageUrl: data.imageUrl ?? '',
   };
 }
+
+/**
+ * Converts an object to a DbSongbook object.
+ */
+export function toDbSong(data: any): DbSong {
+  return {
+    id: data.id ?? '',
+    songbookId: data.songbookId ?? '',
+    number: data.number ?? 0,
+    title: data.title ?? '',
+    author: data.author ?? '',
+    music: data.music ?? '',
+    presentationOrder: data.presentationOrder ?? '',
+    imageUrl: data.imageUrl ?? '',
+  };
+}
+
+/**
+ * Converts an object to a DbLyric object.
+ */
+export function toDbLyric(data: any): DbLyric {
+  return {
+    songId: data.songId ?? '',
+    lyricType: data.lyricType ?? '',
+    verseNumber: data.verseNumber ?? 0,
+    lyrics: data.lyrics ?? '',
+  };
+}

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -2,6 +2,9 @@
  * String Constants for DB Queries
  */
 
+import {v4 as uuidv4} from 'uuid';
+import {LyricType} from './DbModels';
+
 // Normal Queries
 export const QUERY_SELECT_FROM_SONGBOOKS = `SELECT * FROM songbooks`;
 
@@ -17,6 +20,41 @@ export function buildInsertSongbookQuery(
         VALUES ('${id}', '${fullName}', '${staticMetadataLink}','${imageUrl}', now(), now())
         ON CONFLICT DO NOTHING
         RETURNING *; 
+    `.trim();
+}
+
+export function buildInsertSongQuery(
+  id: typeof uuidv4,
+  songbookId: string,
+  number: number,
+  title: string,
+  author: string,
+  music: string,
+  presentationOrder: string,
+  imageUrl: string
+): string {
+  return `
+        INSERT INTO songs
+        (id, songbook_id, number, title, author, music, presentation_order, image_url, inserted_dt, updated_dt)
+        VALUES ('${id}', '${songbookId}', ${number}, '${title}', '${author}', '${music}', '${presentationOrder}',
+        '${imageUrl}', now(), now())
+        ON CONFLICT DO NOTHING
+        RETURNING *
+    `.trim();
+}
+
+export function buildInsertLyricQuery(
+  songId: typeof uuidv4,
+  lyricType: LyricType,
+  verseNumber: number,
+  lyrics: string
+): string {
+  return `
+        INSERT INTO lyrics
+        (song_id, lyric_type, verse_number, lyrics, inserted_dt, updated_dt)
+        VALUES ('${songId}', '${lyricType}', ${verseNumber}, '${lyrics}', now(), now())
+        ON CONFLICT DO NOTHING
+        RETURNING *
     `.trim();
 }
 

--- a/src/helpers/RequestValidationHelpers.ts
+++ b/src/helpers/RequestValidationHelpers.ts
@@ -1,6 +1,7 @@
-import {DbSongbook} from '../db/DbModels';
+import {DbLyric, DbSong, DbSongbook} from '../db/DbModels';
 import {isNumeric} from '../utils/StringUtils';
 import {ValidationError} from './ErrorHelpers';
+import {v4 as uuidv4, validate} from 'uuid';
 
 /**
  * Validates the request of InsertSongbook API
@@ -8,6 +9,27 @@ import {ValidationError} from './ErrorHelpers';
 export function validateInsertSongbookRequest(songbook: DbSongbook) {
   validateString(songbook.id, 'id');
   validateString(songbook.fullName, 'fullName');
+}
+
+/**
+ * Validates the request of InsertSong API
+ */
+export function validateInsertSongRequest(song: DbSong) {
+  validateUuid(song.id, 'id');
+  validateString(song.songbookId, 'songbookId');
+  validateIntegerGreaterThanZero(song.number, 'number');
+  validateString(song.title, 'title');
+  validateString(song.author, 'author');
+  validateString(song.presentationOrder, 'presentationOrder');
+}
+
+/**
+ * Validates the request of InsertLyric API
+ */
+export function validateInsertLyricRequest(lyric: DbLyric) {
+  validateUuid(lyric.songId, 'songId');
+  validateIntegerGreaterThanZero(lyric.verseNumber, 'verseNumber');
+  validateString(lyric.lyrics, 'lyrics');
 }
 
 /**
@@ -22,7 +44,7 @@ export function validateGetSongsRequest(songbookId: string) {
  */
 export function validateGetSongRequest(songbookId: string, number: string) {
   validateString(songbookId, 'songbookId');
-  validateIntegerGreaterThanZero(number, 'number');
+  validateStringIntegerGreaterThanZero(number, 'number');
 }
 
 /**
@@ -37,12 +59,31 @@ function validateString(data: string, fieldName: string) {
 /**
  * Validates a string is a number greater than 0.
  */
-function validateIntegerGreaterThanZero(data: string, fieldName: string) {
+function validateStringIntegerGreaterThanZero(data: string, fieldName: string) {
   if (!isNumeric(data)) {
     throw new ValidationError(`${fieldName} is required and must be a number.`);
   }
   const value = parseInt(data);
-  if (value <= 0) {
+  validateIntegerGreaterThanZero(value, fieldName);
+}
+
+/**
+ * Validates a string is a number greater than 0.
+ */
+function validateIntegerGreaterThanZero(data: number, fieldName: string) {
+  if (data <= 0) {
     throw new ValidationError(`${fieldName} must be greater than 0.`);
+  }
+}
+
+/**
+ * Validates a string is a valid uuid.
+ */
+function validateUuid(data: typeof uuidv4, fieldName: String) {
+  if (
+    !validate(data.toString()) ||
+    data.toString() == '00000000-0000-0000-0000-000000000000'
+  ) {
+    throw new ValidationError(`${fieldName} is not a valid UUID.`);
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,16 +3,20 @@ import express from 'express';
 import cors from 'cors';
 import * as path from 'path';
 import {querySongbooks} from './db/SongsDb';
-import {toDbSongbook} from './db/DbModels';
+import {toDbLyric, toDbSong, toDbSongbook} from './db/DbModels';
 import {
   validateGetSongRequest,
   validateGetSongsRequest,
+  validateInsertLyricRequest,
   validateInsertSongbookRequest,
+  validateInsertSongRequest,
 } from './helpers/RequestValidationHelpers';
 import {
   getSongsMethod,
   getSongWithLyricsMethod,
+  insertLyricMethod,
   insertSongbookMethod,
+  insertSongMethod,
 } from './services/SongsService';
 import {Response} from 'express-serve-static-core';
 import {DatabaseError, ValidationError} from './helpers/ErrorHelpers';
@@ -61,13 +65,41 @@ app.get('/song', async (req, res) => {
   }
 });
 
-// TODO: Make this a real POST api later
-app.get('/createsongbooks', async (req, res) => {
+// Create Songbook API
+app.post('/createsongbook', async (req, res) => {
   try {
-    console.log(`Create Songbooks API Request received: ${req.url}`);
-    const dbSongbook = toDbSongbook(req.query);
+    console.log(`Create Songbook API Request received: ${req.url}`);
+    const dbSongbook = toDbSongbook(req.body);
     validateInsertSongbookRequest(dbSongbook);
     const val = await insertSongbookMethod(dbSongbook);
+    console.log(`Returning ${val}`);
+    res.status(200).send(val ?? {});
+  } catch (e: any) {
+    handleErrorsAndReturn(e, res);
+  }
+});
+
+// Create Song API
+app.post('/createsong', async (req, res) => {
+  try {
+    console.log(`Create Song API Request received: ${req.url}`);
+    const dbSong = toDbSong(req.body);
+    validateInsertSongRequest(dbSong);
+    const val = await insertSongMethod(dbSong);
+    console.log(`Returning ${val}`);
+    res.status(200).send(val ?? {});
+  } catch (e: any) {
+    handleErrorsAndReturn(e, res);
+  }
+});
+
+// Create Lyric API
+app.post('/createlyric', async (req, res) => {
+  try {
+    console.log(`Create Lyric API Request received: ${req.url}`);
+    const dbLyric = toDbLyric(req.body);
+    validateInsertLyricRequest(dbLyric);
+    const val = await insertLyricMethod(dbLyric);
     console.log(`Returning ${val}`);
     res.status(200).send(val ?? {});
   } catch (e: any) {

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -1,5 +1,7 @@
-import {DbSong, DbSongbook, DbSongWithLyrics} from '../db/DbModels';
+import {DbLyric, DbSong, DbSongbook, DbSongWithLyrics} from '../db/DbModels';
 import {
+  insertLyric,
+  insertSong,
   insertSongbook,
   querySongsForSongbook,
   querySongWithLyrics,
@@ -12,6 +14,20 @@ export async function insertSongbookMethod(
   songbook: DbSongbook
 ): Promise<DbSongbook> {
   return await insertSongbook(songbook);
+}
+
+/**
+ * Service logic for insertSong API
+ */
+export async function insertSongMethod(song: DbSong): Promise<DbSong> {
+  return await insertSong(song);
+}
+
+/**
+ * Service logic for insertLyric API
+ */
+export async function insertLyricMethod(lyric: DbLyric): Promise<DbLyric> {
+  return await insertLyric(lyric);
 }
 
 /**

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -8,3 +8,12 @@
 export function isNumeric(word: string): boolean {
   return !isNaN(+word);
 }
+
+/**
+ * Formats a string for entry into the Postgres DB.
+ *
+ * 1. Replaces single quotes with two single quotes.
+ */
+export function formatForDbEntry(text: string): string {
+  return text.replace(/'/g, "''");
+}


### PR DESCRIPTION
Add APIs to insert song and insert lyrics. Chained on top of #18 

I also wrote a script which runs through the SHL songbook and populates the database with all the songs and lyrics.
https://github.com/Church-Life-Apps/Utilities/blob/main/scripts/populate_database_for_shl_songbook.py

Once #18 is merged the basic API is all good and we can do stuff like this
<img width="1439" alt="Screen Shot 2023-02-22 at 2 47 44 PM" src="https://user-images.githubusercontent.com/8559293/220742371-c48e881c-6f95-4fe2-aefd-a1ad6f47de4d.png">

