### PR TITLE
Create Pending Songs Table & some minor edits

### DIFF
--- a/src/__test__/db/SongsDb.test.ts
+++ b/src/__test__/db/SongsDb.test.ts
@@ -57,6 +57,7 @@ const songbookId = 'shl';
 const songbookName = 'Songs and Hymns of Life';
 const smLink = 's_m_link';
 const songbookImageUrl = 'songbook_image_url';
+const openToNewSongs = true;
 const songId = uuidv4();
 const number = 50;
 const title = 'Song Title';
@@ -74,6 +75,7 @@ const testSongbook: DbSongbook = {
   fullName: songbookName,
   staticMetadataLink: smLink,
   imageUrl: songbookImageUrl,
+  openToNewSongs: openToNewSongs,
 };
 
 const testSong: DbSong = {
@@ -163,7 +165,7 @@ describe('Test Songbooks, Songs, and Lyrics Database Tables', () => {
     expect(empty.length).toBe(0);
 
     const updated = await songsDb.upsertSong(testSongUpdated);
-    assertJsonEquality(updated, testSongUpdated)
+    assertJsonEquality(updated, testSongUpdated);
 
     const queriedUpdated = await songsDb.querySongsForSongbook(songbookId);
     assertJsonEquality(queriedUpdated, [testSongUpdated]);

--- a/src/__test__/db/SongsDb.test.ts
+++ b/src/__test__/db/SongsDb.test.ts
@@ -101,8 +101,8 @@ const testSongUpdated = {
   author: 'new author',
   music: 'new music',
   presentationOrder: 'v1 v1 v1 v1 v1',
-  imageUrl: 'new song iamge url',
-  audioUrl: 'new audio url',
+  imageUrl: 'new song image url',
+  audioUrl: 'new song audio url',
 };
 
 const testLyrics: DbLyric[] = [
@@ -224,7 +224,7 @@ describe('Test Database Tables', () => {
     const inserted = await songsDb.insertPendingSong(testPendingSong);
     assertJsonEquality(inserted, testPendingSong);
 
-    const queried = await  songsDb.queryPendingSongs();
+    const queried = await songsDb.queryPendingSongs();
     assertJsonEquality(queried, [testPendingSong]);
 
     const inserted2 = await songsDb.insertPendingSong(testPendingSongUpdated);

--- a/src/__test__/db/SongsDb.test.ts
+++ b/src/__test__/db/SongsDb.test.ts
@@ -88,6 +88,16 @@ const testSong: DbSong = {
   audioUrl: songAudioUrl,
 };
 
+const testSongUpdated = {
+  ...testSong,
+  title: 'new title',
+  author: 'new author',
+  music: 'new music',
+  presentationOrder: 'v1 v1 v1 v1 v1',
+  imageUrl: 'new song iamge url',
+  audioUrl: 'new audio url',
+};
+
 const testLyrics: DbLyric[] = [
   {
     songId: songId,
@@ -143,7 +153,7 @@ describe('Test Songbooks, Songs, and Lyrics Database Tables', () => {
 
   test(`Insert and Get Song Functions`, async () => {
     await songsDb.insertSongbook(testSongbook);
-    const inserted = await songsDb.insertSong(testSong);
+    const inserted = await songsDb.upsertSong(testSong);
     assertJsonEquality(inserted, testSong);
 
     const queried = await songsDb.querySongsForSongbook(songbookId);
@@ -152,15 +162,16 @@ describe('Test Songbooks, Songs, and Lyrics Database Tables', () => {
     const empty = await songsDb.querySongsForSongbook('no songbook id');
     expect(empty.length).toBe(0);
 
-    assertFails(
-      () => songsDb.insertSong(testSong),
-      'Insert song should fail on duplicate id.'
-    );
+    const updated = await songsDb.upsertSong(testSongUpdated);
+    assertJsonEquality(updated, testSongUpdated)
+
+    const queriedUpdated = await songsDb.querySongsForSongbook(songbookId);
+    assertJsonEquality(queriedUpdated, [testSongUpdated]);
   });
 
   test(`Insert Lyrics and Get Lyric Functions`, async () => {
     await songsDb.insertSongbook(testSongbook);
-    await songsDb.insertSong(testSong);
+    await songsDb.upsertSong(testSong);
     const inserted1 = await songsDb.insertLyric(testLyrics[0]);
     const inserted2 = await songsDb.insertLyric(testLyrics[1]);
     const inserted3 = await songsDb.insertLyric(testLyrics[2]);

--- a/src/__test__/db/SongsDb.test.ts
+++ b/src/__test__/db/SongsDb.test.ts
@@ -1,5 +1,11 @@
 import {Pool} from 'pg';
-import {DbLyric, DbSong, DbSongbook, DbSongWithLyrics, LyricType} from '../../db/DbModels';
+import {
+  DbLyric,
+  DbSong,
+  DbSongbook,
+  DbSongWithLyrics,
+  LyricType,
+} from '../../db/DbModels';
 import {
   QUERY_CREATE_LYRICS_TABLE,
   QUERY_CREATE_LYRIC_TYPE_ENUM,
@@ -58,6 +64,7 @@ const author = 'Song Author';
 const music = 'Song Music';
 const presentationOrder = 'v1 c1 v2 c1 v3 c1 v4 c2';
 const songImageUrl = 'song_image_url';
+const songAudioUrl = 'song_audio_url';
 const verse1 = 'Some lyrics for the first verse';
 const verse2 = 'More lyrics for the second verse';
 const chorus = 'Final lyrics for the chorus';
@@ -78,6 +85,7 @@ const testSong: DbSong = {
   music: music,
   presentationOrder: presentationOrder,
   imageUrl: songImageUrl,
+  audioUrl: songAudioUrl,
 };
 
 const testLyrics: DbLyric[] = [
@@ -102,8 +110,8 @@ const testLyrics: DbLyric[] = [
 ];
 
 const testSongWithLyrics: DbSongWithLyrics = {
-    song: testSong,
-    lyrics: testLyrics
+  song: testSong,
+  lyrics: testLyrics,
 };
 
 describe('Test Songbooks, Songs, and Lyrics Database Tables', () => {
@@ -158,7 +166,10 @@ describe('Test Songbooks, Songs, and Lyrics Database Tables', () => {
     const inserted3 = await songsDb.insertLyric(testLyrics[2]);
     assertJsonEquality([inserted1, inserted2, inserted3], testLyrics);
 
-    const queriedSongWithLyrics = await songsDb.querySongWithLyrics(songbookId, number)
+    const queriedSongWithLyrics = await songsDb.querySongWithLyrics(
+      songbookId,
+      number
+    );
     assertJsonEquality(queriedSongWithLyrics, testSongWithLyrics);
 
     assertFails(

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -46,6 +46,20 @@ export interface DbSongWithLyrics {
   lyrics: DbLyric[];
 }
 
+// Data object for pending_songs table
+export interface DbPendingSong {
+  id: string; // uuid
+  songbookId: string;
+  number: number;
+  title: string;
+  author: string;
+  music: string;
+  presentationOrder: string;
+  imageUrl: string;
+  audioUrl: string;
+  lyrics: DbLyric[];
+}
+
 /**
  * Converts an object to a DbSongbook object.
  */
@@ -55,7 +69,7 @@ export function toDbSongbook(data: any): DbSongbook {
     fullName: data.fullName ?? '',
     staticMetadataLink: data.staticMetadataLink ?? '',
     imageUrl: data.imageUrl ?? '',
-    openToNewSongs: data.openToNewSongs ?? false
+    openToNewSongs: data.openToNewSongs ?? false,
   };
 }
 
@@ -85,5 +99,23 @@ export function toDbLyric(data: any): DbLyric {
     lyricType: data.lyricType ?? '',
     verseNumber: data.verseNumber ?? 0,
     lyrics: data.lyrics ?? '',
+  };
+}
+
+/**
+ * Converts an object to a DbPendingSong object.
+ */
+export function toDbPendingSong(data: any): DbPendingSong {
+  return {
+    id: data.id ?? '',
+    songbookId: data.songbookId ?? '',
+    number: data.number ?? 0,
+    title: data.title ?? '',
+    author: data.author ?? '',
+    music: data.music ?? '',
+    presentationOrder: data.presentationOrder ?? '',
+    imageUrl: data.imageUrl ?? '',
+    audioUrl: data.audioUrl ?? '',
+    lyrics: JSON.parse(data.lyrics ?? '[]'),
   };
 }

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -22,14 +22,15 @@ export interface DbSong {
   music: string;
   presentationOrder: string;
   imageUrl: string;
+  audioUrl: string;
 }
 
 // Db Lyric Type Enum
 export enum LyricType {
-  LYRIC_TYPE_VERSE = "LYRIC_TYPE_VERSE",
-  LYRIC_TYPE_PRECHORUS = "LYRIC_TYPE_PRECHORUS",
-  LYRIC_TYPE_CHORUS = "LYRIC_TYPE_CHORUS",
-  LYRIC_TYPE_BRIDGE = "LYRIC_TYPE_BRIDGE",
+  LYRIC_TYPE_VERSE = 'LYRIC_TYPE_VERSE',
+  LYRIC_TYPE_PRECHORUS = 'LYRIC_TYPE_PRECHORUS',
+  LYRIC_TYPE_CHORUS = 'LYRIC_TYPE_CHORUS',
+  LYRIC_TYPE_BRIDGE = 'LYRIC_TYPE_BRIDGE',
 }
 
 // Data object for Lyrics table
@@ -71,6 +72,7 @@ export function toDbSong(data: any): DbSong {
     music: data.music ?? '',
     presentationOrder: data.presentationOrder ?? '',
     imageUrl: data.imageUrl ?? '',
+    audioUrl: data.audioUrl ?? '',
   };
 }
 

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -2,6 +2,8 @@
  * Data Models for inserting and retrieving rows from the database
  */
 
+import {json} from 'stream/consumers';
+
 // Data object for Songbooks table
 export interface DbSongbook {
   id: string;
@@ -106,6 +108,9 @@ export function toDbLyric(data: any): DbLyric {
  * Converts an object to a DbPendingSong object.
  */
 export function toDbPendingSong(data: any): DbPendingSong {
+  const lyrics: DbLyric[] = data.lyrics.map((lyricJson: any) => {
+    return toDbLyric(lyricJson);
+  });
   return {
     id: data.id ?? '',
     songbookId: data.songbookId ?? '',
@@ -116,6 +121,6 @@ export function toDbPendingSong(data: any): DbPendingSong {
     presentationOrder: data.presentationOrder ?? '',
     imageUrl: data.imageUrl ?? '',
     audioUrl: data.audioUrl ?? '',
-    lyrics: JSON.parse(data.lyrics ?? '[]'),
+    lyrics: lyrics,
   };
 }

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -2,14 +2,13 @@
  * Data Models for inserting and retrieving rows from the database
  */
 
-import {v4 as uuidv4} from 'uuid';
-
 // Data object for Songbooks table
 export interface DbSongbook {
   id: string;
   fullName: string;
   staticMetadataLink: string;
   imageUrl: string;
+  openToNewSongs: boolean;
 }
 
 // Data object for Songs table
@@ -56,6 +55,7 @@ export function toDbSongbook(data: any): DbSongbook {
     fullName: data.fullName ?? '',
     staticMetadataLink: data.staticMetadataLink ?? '',
     imageUrl: data.imageUrl ?? '',
+    openToNewSongs: data.openToNewSongs ?? false
   };
 }
 

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -22,7 +22,7 @@ export function buildInsertSongbookQuery(
     `.trim();
 }
 
-export function buildInsertSongQuery(
+export function buildUpsertSongQuery(
   id: string,
   songbookId: string,
   number: number,
@@ -38,7 +38,10 @@ export function buildInsertSongQuery(
         (id, songbook_id, number, title, author, music, presentation_order, image_url, audio_url, inserted_dt, updated_dt)
         VALUES ('${id}', '${songbookId}', ${number}, '${title}', '${author}', '${music}', '${presentationOrder}',
         '${imageUrl}', '${audioUrl}', now(), now())
-        ON CONFLICT DO NOTHING
+        ON CONFLICT (songbook_id, number) DO UPDATE SET
+        title = '${title}', author = '${author}', music = '${music}', presentation_order = '${presentationOrder}',
+        image_url = '${imageUrl}', audio_url = '${audioUrl}', updated_dt = now()
+        WHERE songs.songbook_id = '${songbookId}' AND songs.number = '${number}'
         RETURNING *
     `.trim();
 }
@@ -125,3 +128,6 @@ export const QUERY_CREATE_LYRICS_TABLE = `
         PRIMARY KEY (song_id, lyric_type, verse_number)
     );
 `.trim();
+
+export const QUERY_CREATE_PENDING_SONGS_TABLE = `
+`

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -11,12 +11,13 @@ export function buildInsertSongbookQuery(
   id: string,
   fullName: string,
   staticMetadataLink: string,
-  imageUrl: string
+  imageUrl: string,
+  openToNewSongs: boolean
 ): string {
   return `
         INSERT INTO songbooks 
-        (id, full_name, static_metadata_link, image_url, inserted_dt, updated_dt)
-        VALUES ('${id}', '${fullName}', '${staticMetadataLink}','${imageUrl}', now(), now())
+        (id, full_name, static_metadata_link, image_url, open_to_new_songs, inserted_dt, updated_dt)
+        VALUES ('${id}', '${fullName}', '${staticMetadataLink}','${imageUrl}', '${openToNewSongs}', now(), now())
         ON CONFLICT DO NOTHING
         RETURNING *; 
     `.trim();
@@ -86,6 +87,7 @@ export const QUERY_CREATE_SONGBOOKS_TABLE = `
         full_name varchar(500) UNIQUE NOT NULL,
         static_metadata_link text NOT NULL,
         image_url text NOT NULL,
+        open_to_new_songs boolean NOT NULL,
         inserted_dt timestamptz NOT NULL,
         updated_dt timestamptz NOT NULL
     );
@@ -130,4 +132,4 @@ export const QUERY_CREATE_LYRICS_TABLE = `
 `.trim();
 
 export const QUERY_CREATE_PENDING_SONGS_TABLE = `
-`
+`;

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -2,7 +2,7 @@
  * Strings and functions for DB Queries
  */
 
-import {LyricType} from './DbModels';
+import {DbLyric, LyricType} from './DbModels';
 
 // Normal Queries
 export const QUERY_SELECT_FROM_SONGBOOKS = `SELECT * FROM songbooks`;
@@ -80,6 +80,31 @@ export function buildGetSongWithLyricsQuery(
     `.trim();
 }
 
+export function buildInsertPendingSongQuery(
+  id: string,
+  songbookId: string,
+  number: number,
+  title: string,
+  author: string,
+  music: string,
+  presentationOrder: string,
+  imageUrl: string,
+  audioUrl: string,
+  lyrics: DbLyric[]
+): string {
+  return `
+        INSERT INTO pending_songs
+        (id, songbook_id, number, title, author, music, presentation_order, image_url, audio_url, lyrics, inserted_dt, updated_dt)
+        VALUES ('${id}', '${songbookId}', ${number}, '${title}', '${author}', '${music}', '${presentationOrder}',
+        '${imageUrl}', '${audioUrl}', '${JSON.stringify(lyrics)}', now(), now())
+        ON CONFLICT DO NOTHING
+        RETURNING *
+    `.trim();
+}
+
+export const QUERY_SELECT_FROM_PENDING_SONGS =
+  'SELECT * FROM pending_songs ORDER BY songbook_id ASC, number ASC';
+
 // One-time queries below this line! Should only be called by TEST cases :)
 export const QUERY_CREATE_SONGBOOKS_TABLE = `
     CREATE TABLE IF NOT EXISTS songbooks (
@@ -132,4 +157,18 @@ export const QUERY_CREATE_LYRICS_TABLE = `
 `.trim();
 
 export const QUERY_CREATE_PENDING_SONGS_TABLE = `
-`;
+    CREATE TABLE IF NOT EXISTS pending_songs (
+        id uuid PRIMARY KEY,
+        songbook_id varchar(50) REFERENCES songbooks(id),
+        number integer NOT NULL,
+        title varchar(500) NOT NULL,
+        author varchar(500) NOT NULL,
+        music varchar(500) NOT NULL,
+        presentation_order text NOT NULL,
+        image_url text NOT NULL,
+        audio_url text NOT NULL,
+        lyrics text NOT NULL,
+        inserted_dt timestamptz NOT NULL,
+        updated_dt timestamptz NOT NULL
+    );
+`.trim();

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -30,13 +30,14 @@ export function buildInsertSongQuery(
   author: string,
   music: string,
   presentationOrder: string,
-  imageUrl: string
+  imageUrl: string,
+  audioUrl: string
 ): string {
   return `
         INSERT INTO songs
-        (id, songbook_id, number, title, author, music, presentation_order, image_url, inserted_dt, updated_dt)
+        (id, songbook_id, number, title, author, music, presentation_order, image_url, audio_url, inserted_dt, updated_dt)
         VALUES ('${id}', '${songbookId}', ${number}, '${title}', '${author}', '${music}', '${presentationOrder}',
-        '${imageUrl}', now(), now())
+        '${imageUrl}', '${audioUrl}', now(), now())
         ON CONFLICT DO NOTHING
         RETURNING *
     `.trim();
@@ -97,6 +98,7 @@ export const QUERY_CREATE_SONGS_TABLE = `
         music varchar(500) NOT NULL,
         presentation_order text NOT NULL,
         image_url text NOT NULL,
+        audio_url text NOT NULL,
         inserted_dt timestamptz NOT NULL,
         updated_dt timestamptz NOT NULL,
         UNIQUE(songbook_id, number)

--- a/src/db/DbQueries.ts
+++ b/src/db/DbQueries.ts
@@ -2,6 +2,7 @@
  * Strings and functions for DB Queries
  */
 
+import {formatForDbEntry} from '../utils/StringUtils';
 import {DbLyric, LyricType} from './DbModels';
 
 // Normal Queries
@@ -96,7 +97,8 @@ export function buildInsertPendingSongQuery(
         INSERT INTO pending_songs
         (id, songbook_id, number, title, author, music, presentation_order, image_url, audio_url, lyrics, inserted_dt, updated_dt)
         VALUES ('${id}', '${songbookId}', ${number}, '${title}', '${author}', '${music}', '${presentationOrder}',
-        '${imageUrl}', '${audioUrl}', '${JSON.stringify(lyrics)}', now(), now())
+        '${imageUrl}', '${audioUrl}', 
+        '${formatForDbEntry(JSON.stringify(lyrics))}', now(), now())
         ON CONFLICT DO NOTHING
         RETURNING *
     `.trim();

--- a/src/db/SongsDb.ts
+++ b/src/db/SongsDb.ts
@@ -85,7 +85,8 @@ export class SongsDb {
         songbook.id,
         songbook.fullName,
         songbook.staticMetadataLink,
-        songbook.imageUrl
+        songbook.imageUrl,
+        songbook.openToNewSongs
       )
     ).then((rows) => {
       if (rows.length > 0) {
@@ -150,6 +151,7 @@ export class SongsDb {
       fullName: row.full_name ?? '',
       staticMetadataLink: row.static_metadata_link ?? '',
       imageUrl: row.image_url ?? '',
+      openToNewSongs: row.open_to_new_songs ?? false,
     };
   }
 

--- a/src/db/SongsDb.ts
+++ b/src/db/SongsDb.ts
@@ -109,7 +109,8 @@ export class SongsDb {
         formatForDbEntry(song.author),
         formatForDbEntry(song.music),
         song.presentationOrder,
-        song.imageUrl
+        song.imageUrl,
+        song.audioUrl
       )
     ).then((rows) => {
       if (rows.length > 0) {
@@ -165,6 +166,7 @@ export class SongsDb {
       music: row.music ?? '',
       presentationOrder: row.presentation_order ?? '',
       imageUrl: row.image_url ?? '',
+      audioUrl: row.audio_url ?? '',
     };
   }
 

--- a/src/db/SongsDb.ts
+++ b/src/db/SongsDb.ts
@@ -11,7 +11,7 @@ import {
   buildGetSongWithLyricsQuery,
   buildInsertLyricQuery,
   buildInsertSongbookQuery,
-  buildInsertSongQuery,
+  buildUpsertSongQuery,
   QUERY_SELECT_FROM_SONGBOOKS,
 } from './DbQueries';
 require('dotenv').config();
@@ -97,11 +97,11 @@ export class SongsDb {
   }
 
   /**
-   * Inserts a DbSong into the songs table
+   * Inserts or Updates a DbSong into the songs table
    */
-  async insertSong(song: DbSong): Promise<DbSong> {
+  async upsertSong(song: DbSong): Promise<DbSong> {
     return await this.queryDb(
-      buildInsertSongQuery(
+      buildUpsertSongQuery(
         song.id,
         song.songbookId,
         song.number,

--- a/src/helpers/RequestValidationHelpers.ts
+++ b/src/helpers/RequestValidationHelpers.ts
@@ -1,4 +1,4 @@
-import {DbLyric, DbSong, DbSongbook} from '../db/DbModels';
+import {DbLyric, DbPendingSong, DbSong, DbSongbook} from '../db/DbModels';
 import {isNumeric} from '../utils/StringUtils';
 import {ValidationError} from './ErrorHelpers';
 import {v4 as uuidv4, validate} from 'uuid';
@@ -30,6 +30,19 @@ export function validateInsertLyricRequest(lyric: DbLyric) {
   validateUuid(lyric.songId, 'songId');
   validateIntegerGreaterThanZero(lyric.verseNumber, 'verseNumber');
   validateString(lyric.lyrics, 'lyrics');
+}
+
+/**
+ * Validates the request of InsertPendingSongAPI
+ */
+export function validateInsertPendingSongRequest(pendingSong: DbPendingSong) {
+  validateUuid(pendingSong.id, 'id');
+  validateString(pendingSong.songbookId, 'songbookId');
+  validateIntegerGreaterThanZero(pendingSong.number, 'number');
+  validateString(pendingSong.title, 'title');
+  validateString(pendingSong.author, 'author');
+  validateString(pendingSong.presentationOrder, 'presentationOrder');
+  pendingSong.lyrics.forEach((lyric) => validateInsertLyricRequest(lyric));
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,11 +2,17 @@ import * as dotenv from 'dotenv';
 import express from 'express';
 import cors from 'cors';
 import * as path from 'path';
-import {toDbLyric, toDbSong, toDbSongbook} from './db/DbModels';
+import {
+  toDbLyric,
+  toDbSong,
+  toDbSongbook,
+  toDbPendingSong,
+} from './db/DbModels';
 import {
   validateGetSongRequest,
   validateGetSongsRequest,
   validateInsertLyricRequest,
+  validateInsertPendingSongRequest,
   validateInsertSongbookRequest,
   validateInsertSongRequest,
 } from './helpers/RequestValidationHelpers';
@@ -64,6 +70,15 @@ app.get('/song', async (req, res) => {
   }
 });
 
+// List Pending Songs API
+app.get('/pendingsongs', async (_req, res) => {
+  try {
+    res.send(await songsService.getPendingSongs());
+  } catch (e: any) {
+    handleErrorsAndReturn(e, res);
+  }
+});
+
 // Create Songbook API
 app.post('/songbook', async (req, res) => {
   try {
@@ -71,7 +86,7 @@ app.post('/songbook', async (req, res) => {
     const dbSongbook = toDbSongbook(req.body);
     validateInsertSongbookRequest(dbSongbook);
     const val = await songsService.insertSongbookMethod(dbSongbook);
-    console.log(`Returning ${val}`);
+    console.log(`Returning ${JSON.stringify(val)}`);
     res.send(val ?? {});
   } catch (e: any) {
     handleErrorsAndReturn(e, res);
@@ -85,7 +100,7 @@ app.post('/song', async (req, res) => {
     const dbSong = toDbSong(req.body);
     validateInsertSongRequest(dbSong);
     const val = await songsService.upsertSongMethod(dbSong);
-    console.log(`Returning ${val}`);
+    console.log(`Returning ${JSON.stringify(val)}`);
     res.send(val ?? {});
   } catch (e: any) {
     handleErrorsAndReturn(e, res);
@@ -99,14 +114,28 @@ app.post('/lyric', async (req, res) => {
     const dbLyric = toDbLyric(req.body);
     validateInsertLyricRequest(dbLyric);
     const val = await songsService.insertLyricMethod(dbLyric);
-    console.log(`Returning ${val}`);
+    console.log(`Returning ${JSON.stringify(val)}`);
     res.send(val ?? {});
   } catch (e: any) {
     handleErrorsAndReturn(e, res);
   }
 });
 
-app.get('*', function (request, response) {
+// Create Pending Song API
+app.post('/pendingsong', async (req, res) => {
+  try {
+    console.log(`Create Pending Song API Request received: ${req.url}`);
+    const pendingSong = toDbPendingSong(req.body);
+    validateInsertPendingSongRequest(pendingSong);
+    const val = await songsService.insertPendingSongMethod(pendingSong);
+    console.log(`Returning ${JSON.stringify(val)}`);
+    res.send(val ?? {});
+  } catch (e: any) {
+    handleErrorsAndReturn(e, res);
+  }
+});
+
+app.get('*', function (_request, response) {
   response.sendFile(path.resolve(__dirname, '../web-build', 'index.html'));
 });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ app.get('/song', async (req, res) => {
 });
 
 // Create Songbook API
-app.post('/createsongbook', async (req, res) => {
+app.post('/songbook', async (req, res) => {
   try {
     console.log(`Create Songbook API Request received: ${req.url}`);
     const dbSongbook = toDbSongbook(req.body);
@@ -79,12 +79,12 @@ app.post('/createsongbook', async (req, res) => {
 });
 
 // Create Song API
-app.post('/createsong', async (req, res) => {
+app.post('/song', async (req, res) => {
   try {
     console.log(`Create Song API Request received: ${req.url}`);
     const dbSong = toDbSong(req.body);
     validateInsertSongRequest(dbSong);
-    const val = await songsService.insertSongMethod(dbSong);
+    const val = await songsService.upsertSongMethod(dbSong);
     console.log(`Returning ${val}`);
     res.send(val ?? {});
   } catch (e: any) {
@@ -93,7 +93,7 @@ app.post('/createsong', async (req, res) => {
 });
 
 // Create Lyric API
-app.post('/createlyric', async (req, res) => {
+app.post('/lyric', async (req, res) => {
   try {
     console.log(`Create Lyric API Request received: ${req.url}`);
     const dbLyric = toDbLyric(req.body);

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -1,4 +1,10 @@
-import {DbLyric, DbSong, DbSongbook, DbSongWithLyrics} from '../db/DbModels';
+import {
+  DbLyric,
+  DbPendingSong,
+  DbSong,
+  DbSongbook,
+  DbSongWithLyrics,
+} from '../db/DbModels';
 import {SongsDb} from '../db/SongsDb';
 
 export class SongsService {
@@ -21,6 +27,12 @@ export class SongsService {
     return await this.songsDb.insertLyric(lyric);
   }
 
+  async insertPendingSongMethod(
+    pendingSong: DbPendingSong
+  ): Promise<DbPendingSong> {
+    return await this.songsDb.insertPendingSong(pendingSong);
+  }
+
   // SELECT Functions
   async getSongbooks(): Promise<DbSongbook[]> {
     return await this.songsDb.querySongbooks();
@@ -35,5 +47,9 @@ export class SongsService {
     number: number
   ): Promise<DbSongWithLyrics> {
     return await this.songsDb.querySongWithLyrics(songbookId, number);
+  }
+
+  async getPendingSongs(): Promise<DbPendingSong[]> {
+    return await this.songsDb.queryPendingSongs();
   }
 }

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -13,8 +13,8 @@ export class SongsService {
     return await this.songsDb.insertSongbook(songbook);
   }
 
-  async insertSongMethod(song: DbSong): Promise<DbSong> {
-    return await this.songsDb.insertSong(song);
+  async upsertSongMethod(song: DbSong): Promise<DbSong> {
+    return await this.songsDb.upsertSong(song);
   }
 
   async insertLyricMethod(lyric: DbLyric): Promise<DbLyric> {


### PR DESCRIPTION
Pending Songs table is meant that when someone wants to propose a new song, or suggest an edit to an existing song, they will create a "pending song". This will remain in the pending songs table and not be able to cause harm until someone approves or rejects the pending song.

This will be the DB table which powers song contribution and allow people to suggest typo fixes and stuff.

This PR also contains
* Test cases
* Add `audio_url` to the songs table
* Update the DB method `insertSong` -> `upsertSong` (insert or update)
* Change POST api names slightly
* Add `openToNewSongs` field to songbooks table - If true then this song is open to public contributions. If false, then it's closed (like for completed hymnals like SHL).