### PR TITLE
Create AcceptPendingSong API and RejectPendingSong API

### DIFF
--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -60,6 +60,9 @@ export interface DbPendingSong {
   imageUrl: string;
   audioUrl: string;
   lyrics: DbLyric[];
+  requesterName: string;
+  requesterEmail: string;
+  requesterNote: string;
 }
 
 /**
@@ -122,5 +125,25 @@ export function toDbPendingSong(data: any): DbPendingSong {
     imageUrl: data.imageUrl ?? '',
     audioUrl: data.audioUrl ?? '',
     lyrics: lyrics,
+    requesterName: data.requesterName,
+    requesterEmail: data.requesterEmail,
+    requesterNote: data.requesterNote,
+  };
+}
+
+/**
+ * Converts a DbPendingSong to a DbSong object.
+ */
+export function pendingSongToSong(pendingSong: DbPendingSong): DbSong {
+  return {
+    id: pendingSong.id ?? '',
+    songbookId: pendingSong.songbookId ?? '',
+    number: pendingSong.number ?? 0,
+    title: pendingSong.title ?? '',
+    author: pendingSong.author ?? '',
+    music: pendingSong.music ?? '',
+    presentationOrder: pendingSong.presentationOrder ?? '',
+    imageUrl: pendingSong.imageUrl ?? '',
+    audioUrl: pendingSong.audioUrl ?? '',
   };
 }

--- a/src/helpers/ApiHelpers.ts
+++ b/src/helpers/ApiHelpers.ts
@@ -1,0 +1,33 @@
+import {DbPendingSong, toDbPendingSong} from '../db/DbModels';
+
+/**
+ * Helper functions for API request and response methods
+ */
+
+export interface RejectPendingSongRequest {
+  pendingSong: DbPendingSong;
+  rejectionReason: string;
+}
+
+export function toRejectPendingSongRequest(
+  data: any
+): RejectPendingSongRequest {
+  return {
+    pendingSong: toDbPendingSong(data.pendingSong),
+    rejectionReason: data.rejectionReason ?? '',
+  };
+}
+
+export interface AcceptPendingSongRequest {
+  pendingSong: DbPendingSong;
+  acceptanceNote: string;
+}
+
+export function toAcceptPendingSongRequest(
+  data: any
+): AcceptPendingSongRequest {
+  return {
+    pendingSong: toDbPendingSong(data.pendingSong),
+    acceptanceNote: data.acceptanceNote ?? '',
+  };
+}

--- a/src/helpers/RequestValidationHelpers.ts
+++ b/src/helpers/RequestValidationHelpers.ts
@@ -2,47 +2,51 @@ import {DbLyric, DbPendingSong, DbSong, DbSongbook} from '../db/DbModels';
 import {isNumeric} from '../utils/StringUtils';
 import {ValidationError} from './ErrorHelpers';
 import {v4 as uuidv4, validate} from 'uuid';
+import {AcceptPendingSongRequest, RejectPendingSongRequest} from './ApiHelpers';
 
 /**
  * Validates the request of InsertSongbook API
  */
 export function validateInsertSongbookRequest(songbook: DbSongbook) {
-  validateString(songbook.id, 'id');
-  validateString(songbook.fullName, 'fullName');
+  validateDbSongbook(songbook, '');
 }
 
 /**
  * Validates the request of InsertSong API
  */
 export function validateInsertSongRequest(song: DbSong) {
-  validateUuid(song.id, 'id');
-  validateString(song.songbookId, 'songbookId');
-  validateIntegerGreaterThanZero(song.number, 'number');
-  validateString(song.title, 'title');
-  validateString(song.author, 'author');
-  validateString(song.presentationOrder, 'presentationOrder');
+  validateDbSong(song, '');
 }
 
 /**
  * Validates the request of InsertLyric API
  */
 export function validateInsertLyricRequest(lyric: DbLyric) {
-  validateUuid(lyric.songId, 'songId');
-  validateIntegerGreaterThanZero(lyric.verseNumber, 'verseNumber');
-  validateString(lyric.lyrics, 'lyrics');
+  validateDbLyric(lyric, '');
 }
 
 /**
  * Validates the request of InsertPendingSongAPI
  */
 export function validateInsertPendingSongRequest(pendingSong: DbPendingSong) {
-  validateUuid(pendingSong.id, 'id');
-  validateString(pendingSong.songbookId, 'songbookId');
-  validateIntegerGreaterThanZero(pendingSong.number, 'number');
-  validateString(pendingSong.title, 'title');
-  validateString(pendingSong.author, 'author');
-  validateString(pendingSong.presentationOrder, 'presentationOrder');
-  pendingSong.lyrics.forEach((lyric) => validateInsertLyricRequest(lyric));
+  validateDbPendingSong(pendingSong, '');
+}
+
+/**
+ * Validates the request of RejectPendingSong API
+ */
+export function validateRejectPendingSongRequest(
+  request: RejectPendingSongRequest
+) {
+  validateUuid(request.pendingSong.id, 'id');
+  validateString(request.rejectionReason, 'rejectionReason');
+}
+
+export function validateAcceptPendingSongRequest(
+  request: AcceptPendingSongRequest
+) {
+  validateDbPendingSong(request.pendingSong, 'pendingSong.');
+  validateString(request.acceptanceNote, 'acceptanceNote');
 }
 
 /**
@@ -58,6 +62,49 @@ export function validateGetSongsRequest(songbookId: string) {
 export function validateGetSongRequest(songbookId: string, number: string) {
   validateString(songbookId, 'songbookId');
   validateStringIntegerGreaterThanZero(number, 'number');
+}
+
+/**
+ * Validates a DbSongbook object.
+ */
+function validateDbSongbook(songbook: DbSongbook, prefix: string) {
+  validateString(songbook.id, `${prefix}id`);
+  validateString(songbook.fullName, `${prefix}fullName`);
+}
+
+/**
+ * Validates a DbSong object.
+ */
+function validateDbSong(song: DbSong, prefix: string) {
+  validateUuid(song.id, `${prefix}id`);
+  validateString(song.songbookId, `${prefix}songbookId`);
+  validateIntegerGreaterThanZero(song.number, `${prefix}number`);
+  validateString(song.title, `${prefix}title`);
+  validateString(song.author, `${prefix}author`);
+  validateString(song.presentationOrder, `${prefix}presentationOrder`);
+}
+/**
+ * Validates a DbLyric object.
+ */
+function validateDbLyric(lyric: DbLyric, prefix: string) {
+  validateUuid(lyric.songId, `${prefix}songId`);
+  validateIntegerGreaterThanZero(lyric.verseNumber, `${prefix}verseNumber`);
+  validateString(lyric.lyrics, `${prefix}lyrics`);
+}
+
+/**
+ * Validates a DbPendingSong object.
+ */
+function validateDbPendingSong(pendingSong: DbPendingSong, prefix: string) {
+  validateUuid(pendingSong.id, `${prefix}id`);
+  validateString(pendingSong.songbookId, `${prefix}songbookId`);
+  validateIntegerGreaterThanZero(pendingSong.number, `${prefix}number`);
+  validateString(pendingSong.title, `${prefix}title`);
+  validateString(pendingSong.author, `${prefix}author`);
+  validateString(pendingSong.presentationOrder, `${prefix}presentationOrder`);
+  pendingSong.lyrics.forEach((lyric) =>
+    validateDbLyric(lyric, `${prefix}.lyrics.`)
+  );
 }
 
 /**

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -4,6 +4,7 @@ import {
   DbSong,
   DbSongbook,
   DbSongWithLyrics,
+  pendingSongToSong,
 } from '../db/DbModels';
 import {SongsDb} from '../db/SongsDb';
 
@@ -24,13 +25,45 @@ export class SongsService {
   }
 
   async insertLyricMethod(lyric: DbLyric): Promise<DbLyric> {
-    return await this.songsDb.insertLyric(lyric);
+    return await this.songsDb.upsertLyric(lyric);
   }
 
   async insertPendingSongMethod(
     pendingSong: DbPendingSong
   ): Promise<DbPendingSong> {
     return await this.songsDb.insertPendingSong(pendingSong);
+  }
+
+  async rejectPendingSongMethod(
+    pendingSong: DbPendingSong,
+    rejectionReason: string
+  ): Promise<boolean> {
+    const deletedSong = await this.songsDb.deletePendingSong(pendingSong.id);
+    if (deletedSong != null) {
+      console.log(
+        `Deleted pending song: ${deletedSong.title}; Requested by: ${deletedSong.requesterName}; With rejection reason: ${rejectionReason}.`
+      );
+      // TODO: Send a loving and gentle email to ${deletedSong.requesterEmail} notifying them their song has been rejected.
+      return true;
+    } else {
+      console.log(`Pending song ${pendingSong.id} not found.`);
+      return false;
+    }
+  }
+
+  async acceptPendingSongMethod(
+    pendingSong: DbPendingSong,
+    acceptanceNote: string
+  ): Promise<boolean> {
+    await this.songsDb.acceptPendingSong(pendingSong);
+
+    console.log(
+      `Accepted pending song: ${pendingSong.title}; Requested by: ${pendingSong.requesterName}; With acceptance note: ${acceptanceNote}`
+    );
+    // TODO: Send an appreciative email to ${pendingSong.requesterEmail} with ${acceptanceNote} message,
+    // And a link to the song they just submitted.
+
+    return true;
   }
 
   // SELECT Functions


### PR DESCRIPTION
Adds APIs to accept and reject song edits and requests. This is for when someone proposes and edit or a new song, we will have the power to just call this API and reject it, or accept it and have it be reflected in app immediately.

This PR
* Makes updates to `pending_songs` table - adds requester_ fields
* Create `rejectpendingsong` api – rejects a pending song request by deleting the pending song
* Create `acceptpendingsong` api – accepts the pending song by making the update to the actual song and lyrics, and deleting the pending song
* Add `/api/` to all the API paths
* Fixes some test cases and make more tests for the DB layer