### PR TITLE
Search for songs by title/author/lyrics

### DIFF
--- a/src/__test__/db/SongsDb.test.ts
+++ b/src/__test__/db/SongsDb.test.ts
@@ -8,15 +8,16 @@ import {
   LyricType,
 } from '../../db/DbModels';
 import {
+  QUERY_CREATE_INDEXES,
   QUERY_CREATE_LYRICS_TABLE,
   QUERY_CREATE_LYRIC_TYPE_ENUM,
   QUERY_CREATE_PENDING_SONGS_TABLE,
   QUERY_CREATE_SONGBOOKS_TABLE,
   QUERY_CREATE_SONGS_TABLE,
+  QUERY_DROP_INDEXES,
 } from '../../db/DbQueries';
 import {SongsDb} from '../../db/SongsDb';
 import {v4 as uuidv4} from 'uuid';
-import {formatForDbSearchColumn} from '../../utils/StringUtils';
 import {Song} from '../../models/ApiModels';
 
 require('dotenv').config();
@@ -41,6 +42,7 @@ async function nukeDatabase() {
   await testPool.query('DROP TABLE IF EXISTS pending_songs CASCADE');
   await testPool.query('DROP TABLE IF EXISTS lyrics CASCADE');
   await testPool.query('DROP TYPE IF EXISTS lyric_type');
+  await testPool.query(QUERY_DROP_INDEXES);
 }
 
 async function initializeDatabase() {
@@ -51,6 +53,7 @@ async function initializeDatabase() {
   await testPool.query(QUERY_CREATE_LYRIC_TYPE_ENUM);
   await testPool.query(QUERY_CREATE_LYRICS_TABLE);
   await testPool.query(QUERY_CREATE_PENDING_SONGS_TABLE);
+  await testPool.query(QUERY_CREATE_INDEXES)
 }
 
 async function resetDatabase() {
@@ -116,21 +119,18 @@ const testLyrics: DbLyric[] = [
     lyricType: LyricType.LYRIC_TYPE_VERSE,
     verseNumber: 1,
     lyrics: verse1,
-    searchLyrics: formatForDbSearchColumn(verse1),
   },
   {
     songId: songId,
     lyricType: LyricType.LYRIC_TYPE_VERSE,
     verseNumber: 2,
     lyrics: verse2,
-    searchLyrics: formatForDbSearchColumn(verse2),
   },
   {
     songId: songId,
     lyricType: LyricType.LYRIC_TYPE_CHORUS,
     verseNumber: 1,
     lyrics: chorus,
-    searchLyrics: formatForDbSearchColumn(chorus),
   },
 ];
 
@@ -363,7 +363,7 @@ describe('Test Database Tables', () => {
     const query3 = await songsDb.searchSongsByNumber('50', '');
     assertJsonEquality(query3, [testSong, song5]);
 
-    // TODO: Test string matching on title/author/music/lyrics
+    // TODO: Test string matching on title/author/lyrics
   });
 });
 

--- a/src/__test__/utils/StringUtils.test.ts
+++ b/src/__test__/utils/StringUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   formatForDbEntry,
   formatForDbSearchColumn,
+  formatForPostgresTsQuery,
   isNumeric,
   removeDoubleSpaces,
   removePunctuation,
@@ -35,4 +36,9 @@ test('FormatForDbSearchColumn function works', () => {
   expect(
     formatForDbSearchColumn('@#FORm\nat[] for    search c\n\nolumn..%%$()#{}"')
   ).toBe('form at for search c olumn');
+});
+
+test('FormatForPostgresTsQuery function works', () => {
+  expect(formatForPostgresTsQuery('  ')).toBe('');
+  expect(formatForPostgresTsQuery('    SOMETHING    and another)#@(  ')).toBe('something&and&another');
 });

--- a/src/__test__/utils/StringUtils.test.ts
+++ b/src/__test__/utils/StringUtils.test.ts
@@ -40,5 +40,7 @@ test('FormatForDbSearchColumn function works', () => {
 
 test('FormatForPostgresTsQuery function works', () => {
   expect(formatForPostgresTsQuery('  ')).toBe('');
-  expect(formatForPostgresTsQuery('    SOMETHING    and another)#@(  ')).toBe('something&and&another');
+  expect(formatForPostgresTsQuery('    SOMETHING    and another)#@(  ')).toBe(
+    'something&and&another'
+  );
 });

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -37,8 +37,7 @@ export interface DbLyric {
   songId: string; // uuid
   lyricType: LyricType;
   verseNumber: number;
-  lyrics: string;
-  searchLyrics: string;
+  lyrics: string
 }
 
 // Data object for joined Songs table with Lyrics table

--- a/src/db/DbModels.ts
+++ b/src/db/DbModels.ts
@@ -37,7 +37,7 @@ export interface DbLyric {
   songId: string; // uuid
   lyricType: LyricType;
   verseNumber: number;
-  lyrics: string
+  lyrics: string;
 }
 
 // Data object for joined Songs table with Lyrics table

--- a/src/models/ApiModels.ts
+++ b/src/models/ApiModels.ts
@@ -186,11 +186,6 @@ export function toSearchRequest(data: any): SearchRequest {
   };
 }
 
-export interface SongWithMatchedText {
-  song: Song;
-  matchText: string;
-}
-
 export interface SearchResponse {
-  matchedSongs: SongWithMatchedText[];
+  matchedSongs: Song[];
 }

--- a/src/models/ModelConversion.ts
+++ b/src/models/ModelConversion.ts
@@ -1,6 +1,5 @@
-import {DbLyric, DbPendingSong, DbSong} from '../db/DbModels';
-import {formatForDbSearchColumn} from '../utils/StringUtils';
-import {Lyric, PendingSong, Song, SongWithMatchedText} from './ApiModels';
+import {DbLyric, DbPendingSong} from '../db/DbModels';
+import {Lyric, PendingSong} from './ApiModels';
 
 /**
  * Data model conversion helpers.
@@ -8,16 +7,6 @@ import {Lyric, PendingSong, Song, SongWithMatchedText} from './ApiModels';
  * Data types that have the same fields don't need an explicit function,
  * they can just be used interchangeably by typescript.
  */
-
-export function toDbLyric(lyric: Lyric): DbLyric {
-  return {
-    songId: lyric.songId,
-    lyricType: lyric.lyricType,
-    verseNumber: lyric.verseNumber,
-    lyrics: lyric.lyrics,
-    searchLyrics: formatForDbSearchColumn(lyric.lyrics),
-  };
-}
 
 export function toDbPendingSong(pendingSong: PendingSong): DbPendingSong {
   return {
@@ -30,19 +19,9 @@ export function toDbPendingSong(pendingSong: PendingSong): DbPendingSong {
     presentationOrder: pendingSong.presentationOrder,
     imageUrl: pendingSong.imageUrl,
     audioUrl: pendingSong.audioUrl,
-    lyrics: pendingSong.lyrics.map((lyric) => toDbLyric(lyric)),
+    lyrics: pendingSong.lyrics,
     requesterName: pendingSong.requesterName,
     requesterEmail: pendingSong.requesterEmail,
     requesterNote: pendingSong.requesterNote,
-  };
-}
-
-export function toSongWithMatchedText(
-  song: DbSong | Song,
-  matchText: string
-): SongWithMatchedText {
-  return {
-    song: song,
-    matchText: matchText,
   };
 }

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -1,4 +1,3 @@
-import {DbSong} from '../db/DbModels';
 import {SongsDb} from '../db/SongsDb';
 import {
   Lyric,
@@ -6,13 +5,8 @@ import {
   Song,
   Songbook,
   SongWithLyrics,
-  SongWithMatchedText,
 } from '../models/ApiModels';
-import {
-  toSongWithMatchedText,
-  toDbLyric,
-  toDbPendingSong,
-} from '../models/ModelConversion';
+import {toDbPendingSong} from '../models/ModelConversion';
 import {isNumeric} from '../utils/StringUtils';
 
 export class SongsService {
@@ -32,7 +26,7 @@ export class SongsService {
   }
 
   async insertLyricMethod(lyric: Lyric): Promise<Lyric> {
-    return await this.songsDb.upsertLyric(toDbLyric(lyric));
+    return await this.songsDb.upsertLyric(lyric);
   }
 
   async insertPendingSongMethod(
@@ -93,19 +87,14 @@ export class SongsService {
     return await this.songsDb.queryPendingSongs();
   }
 
-  async searchSongs(
-    searchText: string,
-    songbook: string
-  ): Promise<SongWithMatchedText[]> {
-    let x: DbSong[];
+  async searchSongs(searchText: string, songbook: string): Promise<Song[]> {
     if (isNumeric(searchText)) {
-      x = await this.songsDb.searchSongsByNumber(searchText, songbook);
+      return await this.songsDb.searchSongsByNumber(
+        searchText,
+        songbook
+      );
     } else {
-      x = await this.songsDb.searchSongsByText(searchText, songbook);
+      return await this.songsDb.searchSongsByText(searchText, songbook);
     }
-    return x.map((song) => ({
-      song: song,
-      matchText: '',
-    }));
   }
 }

--- a/src/services/SongsService.ts
+++ b/src/services/SongsService.ts
@@ -89,10 +89,7 @@ export class SongsService {
 
   async searchSongs(searchText: string, songbook: string): Promise<Song[]> {
     if (isNumeric(searchText)) {
-      return await this.songsDb.searchSongsByNumber(
-        searchText,
-        songbook
-      );
+      return await this.songsDb.searchSongsByNumber(searchText, songbook);
     } else {
       return await this.songsDb.searchSongsByText(searchText, songbook);
     }

--- a/src/utils/StringUtils.ts
+++ b/src/utils/StringUtils.ts
@@ -53,3 +53,14 @@ export function formatForDbSearchColumn(text: string): string {
     replaceNewLines(removePunctuation(text)).toLowerCase()
   );
 }
+
+/**
+ * Formats a string for postgres DB ts query.
+ *
+ * Replaces all spaces with an &.
+ */
+export function formatForPostgresTsQuery(text: string): string {
+  return removeDoubleSpaces(
+    removePunctuation(text).trim().toLowerCase()
+  ).replace(/ /g, '&');
+}


### PR DESCRIPTION
Create query to search for songs based on title, author, and lyrics.

Using `explain analyze` in DBeaver to test the speed of this query, with the indexes created, this query can be as fast as ~5-10ms to run, which is pretty fast.
```
Planning Time: 2.090 ms
Execution Time: 6.223 ms
```

This PR also
* Removes the "matched_text" concept and field - it was too hard to implement
* Removes the `search_lyrics` field from the typescript data models - it exists only in the postgres table and is unreadable to humans anyways.
* Adds some tests.


